### PR TITLE
Adjust NoDynamicWhereRule to not restrict the usage likes of wherePivot

### DIFF
--- a/src/Rules/NoDynamicWhereRule.php
+++ b/src/Rules/NoDynamicWhereRule.php
@@ -6,6 +6,7 @@ namespace Vural\LarastanStrictRules\Rules;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use NunoMaduro\Larastan\Methods\BuilderHelper;
 use PhpParser\Node;
@@ -103,7 +104,8 @@ final class NoDynamicWhereRule implements Rule
         if (
             $this->provider->getClass(Model::class)->hasNativeMethod($methodName) ||
             $this->provider->getClass($eloquentBuilder)->hasNativeMethod($methodName) ||
-            $this->provider->getClass(QueryBuilder::class)->hasNativeMethod($methodName)
+            $this->provider->getClass(QueryBuilder::class)->hasNativeMethod($methodName) ||
+            $this->provider->getClass(BelongsToMany::class)->hasNativeMethod($methodName)
         ) {
             return [];
         }

--- a/tests/Rules/NoDynamicWhereRuleTest.php
+++ b/tests/Rules/NoDynamicWhereRuleTest.php
@@ -35,19 +35,19 @@ class NoDynamicWhereRuleTest extends RuleTestCase
         $this->analyse([__DIR__ . '/data/dynamic-where.php'], [
             [
                 "Dynamic where method 'whereBar' should not be used.",
-                20,
+                21,
             ],
             [
                 "Dynamic where method 'whereBar' should not be used.",
-                31,
+                32,
             ],
             [
                 "Dynamic where method 'whereBar' should not be used.",
-                33,
+                34,
             ],
             [
                 "Dynamic where method 'whereBaz' should not be used.",
-                50,
+                51,
             ],
         ]);
     }

--- a/tests/Rules/data/dynamic-where.php
+++ b/tests/Rules/data/dynamic-where.php
@@ -5,6 +5,7 @@ namespace DynamicWhere;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Foo extends Model
 {
@@ -66,5 +67,48 @@ class CustomEloquentBuilder extends Builder
     public function whereBar(string $bar): CustomEloquentBuilder
     {
         return $this->where('bar', $bar);
+    }
+}
+
+class ModelWithPivotWhereClauses extends Model
+{
+    public function fooWherePivot(): BelongsToMany
+    {
+        return $this->belongsToMany(Foo::class)->wherePivot('pivot_field', 1);
+    }
+
+    public function fooWherePivotBetween(): BelongsToMany
+    {
+        return $this->belongsToMany(Foo::class)->wherePivotBetween('pivot_field', [1, 2]);
+    }
+
+    public function fooWherePivotNotBetween(): BelongsToMany
+    {
+        return $this->belongsToMany(Foo::class)->wherePivotNotBetween('pivot_field', [1, 2]);
+    }
+
+    public function fooWherePivotIn(): BelongsToMany
+    {
+        return $this->belongsToMany(Foo::class)->wherePivotIn('pivot_field', [1, 2]);
+    }
+
+    public function fooWithPivotValue(): BelongsToMany
+    {
+        return $this->belongsToMany(Foo::class)->withPivotValue('pivot_field', 1);
+    }
+
+    public function fooWherePivotNotIn(): BelongsToMany
+    {
+        return $this->belongsToMany(Foo::class)->wherePivotNotIn('pivot_field', [1, 2]);
+    }
+
+    public function fooWherePivotNull(): BelongsToMany
+    {
+        return $this->belongsToMany(Foo::class)->wherePivotNull('pivot_field');
+    }
+
+    public function fooWherePivotNotNull(): BelongsToMany
+    {
+        return $this->belongsToMany(Foo::class)->wherePivotNotNull('pivot_field');
     }
 }


### PR DESCRIPTION
This adds BelongsToMany to be looked at so that wherePivot (and other pivot related methods) are not detected as Dynamic wheres