### PR TITLE
feat: add PHPStan error identifiers

### DIFF
--- a/src/Rules/ListenerShouldHaveVoidReturnTypeRule.php
+++ b/src/Rules/ListenerShouldHaveVoidReturnTypeRule.php
@@ -73,7 +73,11 @@ class ListenerShouldHaveVoidReturnTypeRule implements Rule
         }
 
         if (! (new VoidType())->isSuperTypeOf(ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getReturnType())->yes()) {
-            return [RuleErrorBuilder::message("Listeners handle method should have 'void' return type.")->build()];
+            return [
+                RuleErrorBuilder::message("Listeners handle method should have 'void' return type.")
+                    ->identifier('larastanStrictRules.listenerShouldHaveVoidReturnType')
+                    ->build(),
+            ];
         }
 
         return [];

--- a/src/Rules/NoDynamicWhereRule.php
+++ b/src/Rules/NoDynamicWhereRule.php
@@ -122,7 +122,9 @@ final class NoDynamicWhereRule implements Rule
             RuleErrorBuilder::message(sprintf(
                 "Dynamic where method '%s' should not be used.",
                 $methodName,
-            ))->build(),
+            ))
+                ->identifier('larastanStrictRules.noDynamicWhere')
+                ->build(),
         ];
     }
 

--- a/src/Rules/NoFacadeRule.php
+++ b/src/Rules/NoFacadeRule.php
@@ -53,7 +53,9 @@ final class NoFacadeRule implements Rule
                     RuleErrorBuilder::message(sprintf(
                         '%s facade should not be used.',
                         $className,
-                    ))->build(),
+                    ))
+                        ->identifier('larastanStrictRules.noFacadeRule')
+                        ->build(),
                 ];
             }
         } catch (ClassNotFoundException) {
@@ -62,7 +64,9 @@ final class NoFacadeRule implements Rule
                     RuleErrorBuilder::message(sprintf(
                         '%s facade should not be used.',
                         $className,
-                    ))->build(),
+                    ))
+                        ->identifier('larastanStrictRules.noFacade')
+                        ->build(),
                 ];
             }
         }

--- a/src/Rules/NoGlobalLaravelFunctionRule.php
+++ b/src/Rules/NoGlobalLaravelFunctionRule.php
@@ -74,7 +74,9 @@ final class NoGlobalLaravelFunctionRule implements Rule
                 RuleErrorBuilder::message(sprintf(
                     "Global helper function '%s' should not be used.",
                     $node->name,
-                ))->build(),
+                ))
+                    ->identifier('larastanStrictRules.noGlobalLaravelFunction')
+                    ->build(),
             ];
         }
 

--- a/src/Rules/NoLocalQueryScopeRule.php
+++ b/src/Rules/NoLocalQueryScopeRule.php
@@ -81,6 +81,10 @@ final class NoLocalQueryScopeRule implements Rule
             return [];
         }
 
-        return [RuleErrorBuilder::message('Local query scopes should not be used.')->build()];
+        return [
+            RuleErrorBuilder::message('Local query scopes should not be used.')
+                ->identifier('larastanStrictRules.noLocalQueryScope')
+                ->build(),
+        ];
     }
 }

--- a/src/Rules/NoPropertyAccessorRule.php
+++ b/src/Rules/NoPropertyAccessorRule.php
@@ -55,6 +55,10 @@ final class NoPropertyAccessorRule implements Rule
             return [];
         }
 
-        return [RuleErrorBuilder::message('Model property accessors should not be used.')->build()];
+        return [
+            RuleErrorBuilder::message('Model property accessors should not be used.')
+                ->identifier('larastanStrictRules.noPropertyAccessor')
+                ->build(),
+        ];
     }
 }

--- a/src/Rules/NoValidationInControllerRule.php
+++ b/src/Rules/NoValidationInControllerRule.php
@@ -56,12 +56,24 @@ final class NoValidationInControllerRule implements Rule
 
         if ($calledOn instanceof ObjectType) {
             if ($calledOn->isInstanceOf(Request::class)->yes()) {
-                return [RuleErrorBuilder::message('Request validation should be done in FormRequest not in Controller.')->build()];
+                return [
+                    RuleErrorBuilder::message('Request validation should be done in FormRequest not in Controller.')
+                        ->identifier('larastanStrictRules.noValidationInController')
+                        ->build(),
+                ];
             }
         } elseif (($calledOn instanceof ThisType) && $calledOn->getStaticObjectType()->isInstanceOf(Controller::class)->yes()) {
-            return [RuleErrorBuilder::message('Request validation should be done in FormRequest not in Controller.')->build()];
+            return [
+                RuleErrorBuilder::message('Request validation should be done in FormRequest not in Controller.')
+                    ->identifier('larastanStrictRules.noValidationInController')
+                    ->build(),
+            ];
         } elseif ($calledOn instanceof UnionType && $calledOn->accepts(new ObjectType(Request::class), true)->yes()) {
-            return [RuleErrorBuilder::message('Request validation should be done in FormRequest not in Controller.')->build()];
+            return [
+                RuleErrorBuilder::message('Request validation should be done in FormRequest not in Controller.')
+                    ->identifier('larastanStrictRules.noValidationInController')
+                    ->build(),
+            ];
         }
 
         return [];

--- a/src/Rules/ScopeShouldReturnQueryBuilderRule.php
+++ b/src/Rules/ScopeShouldReturnQueryBuilderRule.php
@@ -83,11 +83,19 @@ final class ScopeShouldReturnQueryBuilderRule implements Rule
         $returnType = $parametersAcceptor->getReturnType();
 
         if (! ($returnType instanceof ObjectType)) {
-            return [RuleErrorBuilder::message('Query scope should return query builder instance.')->build()];
+            return [
+                RuleErrorBuilder::message('Query scope should return query builder instance.')
+                    ->identifier('larastanStrictRules.scopeShouldReturnQueryBuilderRule')
+                    ->build(),
+            ];
         }
 
         if ($returnType->getClassName() !== Builder::class && ! $this->provider->getClass($returnType->getClassName())->isSubclassOf(Builder::class)) {
-            return [RuleErrorBuilder::message('Query scope should return query builder instance.')->build()];
+            return [
+                RuleErrorBuilder::message('Query scope should return query builder instance.')
+                    ->identifier('larastanStrictRules.scopeShouldReturnQueryBuilderRule')
+                    ->build(),
+            ];
         }
 
         return [];


### PR DESCRIPTION
This PR adds error identifiers to allow ignoring errors in the new `// @phpstan-ignore ` comment format. I'm assuming `larastanStrictRules` is ok as a base identifier, but happy to change this if you want to prefix it with `canvural` or similar.

This allows for something like:
```php
Cache::forget('abc'); // @phpstan-ignore larastanStrictRules.noFacadeRule
```