### PR TITLE
feat: improve conditional tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,12 @@ This rule disallows the usage of Laravel Facades. Also, checks for the real time
 
 This rule disallows the usage of global helper functions that comes with Laravel.
 
-If you want to allow some functions, you can use the `allowedFunctions` parameter for this rule. Like so:
+If you want to allow some functions, you can use the `allowedGlobalFunctions` parameter. Like so:
 ```neon
--
-    class: Vural\LarastanStrictRules\Rules\NoGlobalLaravelFunctionRule
-    arguments:
-        allowedFunctions:
-            - app
-            - event
+parameters:
+    allowedGlobalFunctions:
+        - app
+        - event
 ```
 
 #### `NoValidationInControllerRule`
@@ -107,12 +105,10 @@ If you return `false` from an event listener, Laravel will stop the propagation 
 
 You need to configure this rule by adding the directories that your event listeners are in to the `listenerPaths` parameter:
 ```neon
--
-    class: Vural\LarastanStrictRules\Rules\ListenerShouldHaveVoidReturnTypeRule
-    arguments:
-        listenerPaths:
-            - app/Listeners
-            - app/DomainA/Listeners
+parameters:
+    listenerPaths:
+        - app/Listeners
+        - app/DomainA/Listeners
 ```
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -16,25 +16,47 @@ composer require --dev canvural/larastan-strict-rules
 
 To enable all the rules, include `rules.neon` in your project's PHPStan config:
 
-```
+```neon
 includes:
     - vendor/canvural/larastan-strict-rules/rules.neon
 ```
 
+## Disabling rules
+
+You can disable rules using configuration parameters:
+
+```neon
+parameters:
+    larastanStrictRules:
+        noDynamicWhere: false
+        noFacade: false
+        noGlobalLaravelFunction: false
+        noLocalQueryScope: false
+        noPropertyAccessor: false
+        noValidationInController: false
+        scopeShouldReturnQueryBuilder: false
+        listenerShouldHaveVoidReturnType: false
+```
 
 ## Enabling rules one-by-one
-If you don't want to start using all the available strict rules at once but only one or two, you can! Just don't include the whole `rules.neon` from this package in your configuration, but look at its contents and copy only the rules you want to your configuration under the `services` key. For example:
 
+If you don't want to start using all the available strict rules at once but only one or two, you can!
+
+You can disable all rules from the included `rules.neon` with:
+
+```neon
+parameters:
+	larastanStrictRules:
+		allRules: false
 ```
-services:
-    -
-        class: Vural\LarastanStrictRules\Rules\NoDynamicWhereRule
-        tags:
-            - phpstan.rules.rule
-    -
-        class: Vural\LarastanStrictRules\Rules\NoFacadeRule
-        tags:
-            - phpstan.rules.rule
+
+Then you can re-enable individual rules with configuration parameters:
+
+```neon
+parameters:
+	larastanStrictRules:
+		allRules: false
+		noDynamicWhere: true
 ```
 
 ## Rules

--- a/rules.neon
+++ b/rules.neon
@@ -1,26 +1,28 @@
 parameters:
     larastanStrictRules:
-        noDynamicWhere: true
-        noFacade: true
-        noGlobalLaravelFunction: true
-        noLocalQueryScope: false
-        noPropertyAccessor: false
-        noValidationInController: true
-        scopeShouldReturnQueryBuilder: true
-        listenerShouldHaveVoidReturnType: true
+        allRules: true
+        noDynamicWhere: %larastanStrictRules.allRules%
+        noFacade: %larastanStrictRules.allRules%
+        noGlobalLaravelFunction: %larastanStrictRules.allRules%
+        noLocalQueryScope: %larastanStrictRules.allRules%
+        noPropertyAccessor: %larastanStrictRules.allRules%
+        noValidationInController: %larastanStrictRules.allRules%
+        scopeShouldReturnQueryBuilder: %larastanStrictRules.allRules%
+        listenerShouldHaveVoidReturnType: %larastanStrictRules.allRules%
     allowedGlobalFunctions: []
     listenerPaths: []
 
 parametersSchema:
     larastanStrictRules: structure([
-      noDynamicWhere: bool(),
-      noFacade: bool(),
-      noGlobalLaravelFunction: bool(),
-      noLocalQueryScope: bool(),
-      noPropertyAccessor: bool(),
-      noValidationInController: bool(),
-      scopeShouldReturnQueryBuilder: bool(),
-      listenerShouldHaveVoidReturnType: bool(),
+      allRules: anyOf(bool(), arrayOf(bool())),
+      noDynamicWhere: anyOf(bool(), arrayOf(bool())),
+      noFacade: anyOf(bool(), arrayOf(bool())),
+      noGlobalLaravelFunction: anyOf(bool(), arrayOf(bool())),
+      noLocalQueryScope: anyOf(bool(), arrayOf(bool())),
+      noPropertyAccessor: anyOf(bool(), arrayOf(bool())),
+      noValidationInController: anyOf(bool(), arrayOf(bool())),
+      scopeShouldReturnQueryBuilder: anyOf(bool(), arrayOf(bool())),
+      listenerShouldHaveVoidReturnType: anyOf(bool(), arrayOf(bool())),
     ])
     allowedGlobalFunctions: listOf(string())
     listenerPaths: listOf(string())


### PR DESCRIPTION
This improves the conditional tags and adds documentation for using them.

Changes allow setting a `allRules` parameter to `false`, in order to enable each value separately. Whereas before we'd have to disable each one we don't want.

It also better allows overrides from different config files. You could disable one of the rules in a base config, but enable it higher up the chain.

I've also moved the parameters in the docs to be top-level, rather than needing to copy the rule block.