### PR TITLE
chore: remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "doctrine/coding-standard": "^12",
     "phpstan/phpstan-phpunit": "^1.3",
     "phpunit/phpunit": "^9.6 || ^10",
-    "orchestra/testbench": "^v7.47.0 || ^8.13.0 || ^9.0.9",
-    "roave/security-advisories": "dev-latest"
+    "orchestra/testbench": "^v7.47.0 || ^8.13.0 || ^9.0.9"
   },
   "config": {
     "sort-packages": true,


### PR DESCRIPTION
This PR removes `roave/security-advisories` package. Didn't make too much sense for a small library and was causing issues with CI