### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ If the project maintainer has any additional requirements, you will find them li
 
 ### Coding Standards
 
-We are using [`squizlabs/PHP_CodeSniffer`](https://github.com/squizlabs/PHP_CodeSniffer) to enforce coding standards in PHP files.
+We are using [`squizlabs/PHP_CodeSniffer`](https://github.com/PHPCSStandards/PHP_CodeSniffer) to enforce coding standards in PHP files.
 
 Run
 


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932