### PR TITLE
fix(ListenerShouldHaveVoidReturnTypeRule.php): Do not report middlewares & commands as false positives

### DIFF
--- a/src/Rules/ListenerShouldHaveVoidReturnTypeRule.php
+++ b/src/Rules/ListenerShouldHaveVoidReturnTypeRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Vural\LarastanStrictRules\Rules;
 
+use Illuminate\Console\Command;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\File\FileHelper;
@@ -48,6 +49,11 @@ class ListenerShouldHaveVoidReturnTypeRule implements Rule
         $methodReflection = $scope->getFunction();
 
         if ($methodReflection === null) {
+            return [];
+        }
+
+        // Console commands also have a handle method, but they must return an exit code
+        if ($classReflection->is(Command::class)) {
             return [];
         }
 

--- a/src/Rules/ListenerShouldHaveVoidReturnTypeRule.php
+++ b/src/Rules/ListenerShouldHaveVoidReturnTypeRule.php
@@ -137,7 +137,7 @@ class ListenerShouldHaveVoidReturnTypeRule implements Rule
         return $this->isRequest($parameters[0]);
     }
 
-    private function isRequest(ParameterReflection $parameter): bool
+    protected function isRequest(ParameterReflection $parameter): bool
     {
         $type = $parameter->getType();
 
@@ -148,7 +148,7 @@ class ListenerShouldHaveVoidReturnTypeRule implements Rule
         return (new ObjectType(SymfonyRequest::class))->isSuperTypeOf($type)->yes();
     }
 
-    private function isNextClosure(ParameterReflection $parameter): bool
+    protected function isNextClosure(ParameterReflection $parameter): bool
     {
         $type = $parameter->getType();
 

--- a/src/Rules/ListenerShouldHaveVoidReturnTypeRule.php
+++ b/src/Rules/ListenerShouldHaveVoidReturnTypeRule.php
@@ -4,16 +4,23 @@ declare(strict_types=1);
 
 namespace Vural\LarastanStrictRules\Rules;
 
+use Closure;
 use Illuminate\Console\Command;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\File\FileHelper;
 use PHPStan\Node\InClassMethodNode;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Reflection\ParametersAcceptorSelector;
+use PHPStan\Reflection\Php\PhpFunctionFromParserNodeReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\VoidType;
+use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 
 use function count;
 use function stripos;
@@ -52,8 +59,7 @@ class ListenerShouldHaveVoidReturnTypeRule implements Rule
             return [];
         }
 
-        // Console commands also have a handle method, but they must return an exit code
-        if ($classReflection->is(Command::class)) {
+        if ($this->isExcluded($classReflection, $methodReflection)) {
             return [];
         }
 
@@ -87,5 +93,69 @@ class ListenerShouldHaveVoidReturnTypeRule implements Rule
         }
 
         return [];
+    }
+
+    protected function isExcluded(ClassReflection $classReflection, PhpFunctionFromParserNodeReflection $methodReflection): bool
+    {
+        if ($this->isCommand($classReflection)) {
+            return true;
+        }
+
+        if ($this->isMiddleware($classReflection, $methodReflection)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected function isCommand(ClassReflection $classReflection): bool
+    {
+        return $classReflection->is(Command::class);
+    }
+
+    /**
+     * Laravel middlewares do not implement any contract, so they can only be
+     * recognized by the signature of their handle method: they accept the
+     * request as the first parameter and the "next" closure as the second one.
+     */
+    protected function isMiddleware(ClassReflection $classReflection, PhpFunctionFromParserNodeReflection $methodReflection): bool
+    {
+        if ($classReflection->isInterface() || $classReflection->isEnum()) {
+            return false;
+        }
+
+        $parameters = ParametersAcceptorSelector::selectSingle($methodReflection->getVariants())->getParameters();
+
+        if (count($parameters) < 2) {
+            return false;
+        }
+
+        if (! $this->isNextClosure($parameters[1])) {
+            return false;
+        }
+
+        return $this->isRequest($parameters[0]);
+    }
+
+    private function isRequest(ParameterReflection $parameter): bool
+    {
+        $type = $parameter->getType();
+
+        if ($type instanceof MixedType) {
+            return $parameter->getName() === 'request';
+        }
+
+        return (new ObjectType(SymfonyRequest::class))->isSuperTypeOf($type)->yes();
+    }
+
+    private function isNextClosure(ParameterReflection $parameter): bool
+    {
+        $type = $parameter->getType();
+
+        if ($type instanceof MixedType) {
+            return $parameter->getName() === 'next';
+        }
+
+        return (new ObjectType(Closure::class))->isSuperTypeOf($type)->yes();
     }
 }

--- a/tests/Rules/ListenerShouldHaveVoidReturnTypeRuleTest.php
+++ b/tests/Rules/ListenerShouldHaveVoidReturnTypeRuleTest.php
@@ -38,4 +38,9 @@ class ListenerShouldHaveVoidReturnTypeRuleTest extends RuleTestCase
             ],
         ]);
     }
+
+    public function testRuleDoesNotReportCommandAsFalsePositive(): void
+    {
+        $this->analyse([__DIR__ . '/data/Commands/FooCommand.php'], []);
+    }
 }

--- a/tests/Rules/ListenerShouldHaveVoidReturnTypeRuleTest.php
+++ b/tests/Rules/ListenerShouldHaveVoidReturnTypeRuleTest.php
@@ -37,10 +37,9 @@ class ListenerShouldHaveVoidReturnTypeRuleTest extends RuleTestCase
                 23,
             ],
         ]);
-    }
 
-    public function testRuleDoesNotReportCommandAsFalsePositive(): void
-    {
+        $this->analyse([__DIR__ . '/data/Middlewares/FooMiddleware.php'], []);
+
         $this->analyse([__DIR__ . '/data/Commands/FooCommand.php'], []);
     }
 }

--- a/tests/Rules/data/Commands/FooCommand.php
+++ b/tests/Rules/data/Commands/FooCommand.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace data\Commands;
+
+use Illuminate\Console\Command;
+
+class FooCommand extends Command
+{
+    public function handle(): int
+    {
+        return self::SUCCESS;
+    }
+}

--- a/tests/Rules/data/Commands/FooCommand.php
+++ b/tests/Rules/data/Commands/FooCommand.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace data\Commands;
+namespace Commands;
 
 use Illuminate\Console\Command;
 

--- a/tests/Rules/data/Middlewares/FooMiddleware.php
+++ b/tests/Rules/data/Middlewares/FooMiddleware.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace data\Middlewares;
+namespace Middlewares;
 
 use Closure;
 use Illuminate\Http\Request;

--- a/tests/Rules/data/Middlewares/FooMiddleware.php
+++ b/tests/Rules/data/Middlewares/FooMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace data\Middlewares;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class FooMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        return $next($request);
+    }
+}


### PR DESCRIPTION
Closes #211

The changes now detect Laravel commands via an instanceof check & try to detect middlewares however possible, since there is no contract available for check.